### PR TITLE
OEL-50: Create News content type / OEL-50, OEL-52, OEL-53.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,13 @@
         "drupal/core": "^8.7"
     },
     "require-dev": {
-        "composer/installers": "~1.5",
+        "composer/installers": "^1.11",
+	"drupal/drupal-extension": "~4.0",
+	"drush/drush": "^10.4",
+	"openeuropa/code-review": "~1.0@beta",
+	"openeuropa/drupal-core-require-dev": "^8 || ^9",
+	"openeuropa/task-runner": "~1.0@beta",
+	"phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.3",
+	"drupal/core-composer-scaffold": "^8 || ^9",
+	"drupal/core-recommended": "^8 || ^9",
         "cweagans/composer-patches": "~1.0",
         "drupal/core": "^8.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.7",
-        "php": ">=7.2"
+        "php": ">=7.2",
+        "cweagans/composer-patches": "~1.0",
+        "drupal/core": "^8.7"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/config/install/core.date_format.publication_date.yml
+++ b/config/install/core.date_format.publication_date.yml
@@ -1,0 +1,7 @@
+langcode: und
+status: true
+dependencies: {  }
+id: publication_date
+label: 'Publication Date'
+locked: false
+pattern: 'd M Y'

--- a/config/install/core.entity_form_display.media.featured_media.default.yml
+++ b/config/install/core.entity_form_display.media.featured_media.default.yml
@@ -1,0 +1,73 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.featured_media.field_media_image
+    - image.style.thumbnail
+    - media.type.featured_media
+  module:
+    - field_layout
+    - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: media.featured_media.default
+targetEntityType: media
+bundle: featured_media
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_image:
+    weight: 0
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_form_display.media.featured_media.media_library.yml
+++ b/config/install/core.entity_form_display.media.featured_media.media_library.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.featured_media.field_media_image
+    - image.style.thumbnail
+    - media.type.featured_media
+  module:
+    - field_layout
+    - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: media.featured_media.media_library
+targetEntityType: media
+bundle: featured_media
+mode: media_library
+content:
+  field_media_image:
+    weight: -50
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  status: true
+  uid: true

--- a/config/install/core.entity_form_display.node.news.default.yml
+++ b/config/install/core.entity_form_display.node.news.default.yml
@@ -1,0 +1,116 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.news.body
+    - field.field.node.news.field_oel_news_featured_media
+    - field.field.node.news.field_oel_news_introduction
+    - field.field.node.news.field_oel_news_publication_date
+    - field.field.node.news.layout_builder__layout
+    - node.type.news
+  module:
+    - datetime
+    - field_layout
+    - layout_discovery
+    - media_library
+    - text
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: node.news.default
+targetEntityType: node
+bundle: news
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_oel_news_featured_media:
+    type: media_library_widget
+    weight: 1
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_oel_news_introduction:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_oel_news_publication_date:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  langcode:
+    type: language_select
+    weight: 5
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 8
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 9
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 10
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 6
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden:
+  layout_builder__layout: true

--- a/config/install/core.entity_view_display.media.featured_media.default.yml
+++ b/config/install/core.entity_view_display.media.featured_media.default.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.featured_media.field_media_image
+    - image.style.large
+    - media.type.featured_media
+  module:
+    - image
+id: media.featured_media.default
+targetEntityType: media
+bundle: featured_media
+mode: default
+content:
+  field_media_image:
+    label: visually_hidden
+    weight: 0
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.featured_media.media_library.yml
+++ b/config/install/core.entity_view_display.media.featured_media.media_library.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.featured_media.field_media_image
+    - image.style.medium
+    - media.type.featured_media
+  module:
+    - image
+id: media.featured_media.media_library
+targetEntityType: media
+bundle: featured_media
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_image: true
+  langcode: true
+  name: true
+  uid: true

--- a/config/install/core.entity_view_display.node.news.cards.yml
+++ b/config/install/core.entity_view_display.node.news.cards.yml
@@ -1,0 +1,138 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.cards
+    - field.field.node.news.body
+    - field.field.node.news.field_oel_news_featured_media
+    - field.field.node.news.field_oel_news_introduction
+    - field.field.node.news.field_oel_news_publication_date
+    - field.field.node.news.layout_builder__layout
+    - node.type.news
+  module:
+    - field_layout
+    - layout_builder
+    - layout_discovery
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Media
+        components:
+          c3000275-9bdf-42a0-ba1d-b099c10a881c:
+            uuid: c3000275-9bdf-42a0-ba1d-b099c10a881c
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_featured_media'
+              label: 'Featured media'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: media_thumbnail
+                settings:
+                  image_style: thumbnail
+                  image_link: content
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: 'Main content'
+        components:
+          cfe29469-e427-4e5b-a6a6-5f265c3fe232:
+            uuid: cfe29469-e427-4e5b-a6a6-5f265c3fe232
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_publication_date'
+              label: 'Publication date'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: datetime_custom
+                settings:
+                  timezone_override: ''
+                  date_format: 'd M Y'
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 1
+          8ea2d22b-7c30-4f69-bc67-14cebc27b815:
+            uuid: 8ea2d22b-7c30-4f69-bc67-14cebc27b815
+            region: content
+            configuration:
+              id: 'field_block:node:news:title'
+              label: Title
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: string
+                settings:
+                  link_to_entity: true
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+          6cfa9a79-e255-4702-b211-b10e72f2c757:
+            uuid: 6cfa9a79-e255-4702-b211-b10e72f2c757
+            region: content
+            configuration:
+              id: 'field_block:node:news:uid'
+              label: 'Authored by'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: author
+                settings: {  }
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 2
+        third_party_settings: {  }
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: node.news.cards
+targetEntityType: node
+bundle: news
+mode: cards
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_oel_news_featured_media: true
+  field_oel_news_introduction: true
+  field_oel_news_publication_date: true
+  langcode: true
+  layout_builder__layout: true

--- a/config/install/core.entity_view_display.node.news.default.yml
+++ b/config/install/core.entity_view_display.node.news.default.yml
@@ -1,0 +1,232 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.news.body
+    - field.field.node.news.field_oel_news_featured_media
+    - field.field.node.news.field_oel_news_introduction
+    - field.field.node.news.field_oel_news_publication_date
+    - field.field.node.news.layout_builder__layout
+    - node.type.news
+  module:
+    - field_layout
+    - layout_builder
+    - layout_discovery
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: true
+    enabled: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Metadata
+        components:
+          8dcfe9f3-d516-4d63-8857-8b876a273992:
+            uuid: 8dcfe9f3-d516-4d63-8857-8b876a273992
+            region: content
+            configuration:
+              id: 'field_block:node:news:type'
+              label: 'Content type'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: entity_reference_label
+                settings:
+                  link: false
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+            additional: {  }
+            weight: 1
+          49632e3f-b4db-4963-8102-1086ec19d7fe:
+            uuid: 49632e3f-b4db-4963-8102-1086ec19d7fe
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_publication_date'
+              label: 'Publication date'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: above
+                type: datetime_default
+                settings:
+                  timezone_override: ''
+                  format_type: publication_date
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+            additional: {  }
+            weight: 2
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Title
+        components:
+          7e64a8e1-e982-4d8c-95eb-bf8cd39f6797:
+            uuid: 7e64a8e1-e982-4d8c-95eb-bf8cd39f6797
+            region: content
+            configuration:
+              id: 'field_block:node:news:title'
+              label: Title
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: above
+                type: text_field_formatter
+                settings:
+                  link_to_entity: 1
+                  wrap_tag: h1
+                  wrap_class: ''
+                  wrap_attributes: ''
+                  override_link_label: ''
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Author
+        components:
+          4f2fb92e-3ff5-4457-98fe-39de65d37166:
+            uuid: 4f2fb92e-3ff5-4457-98fe-39de65d37166
+            region: content
+            configuration:
+              id: 'field_block:node:news:uid'
+              label: 'Authored by'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: author
+                settings: {  }
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Introduction
+        components:
+          1b8f2f7c-7309-4cea-a6b8-0f0dac87066d:
+            uuid: 1b8f2f7c-7309-4cea-a6b8-0f0dac87066d
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_introduction'
+              label: Introduction
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: basic_string
+                settings: {  }
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 1
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: 'Featured Media'
+        components:
+          3f1caa29-2d00-45ff-a38a-a9232cffea0c:
+            uuid: 3f1caa29-2d00-45ff-a38a-a9232cffea0c
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_featured_media'
+              label: 'Featured media'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: media_thumbnail
+                settings:
+                  image_style: ''
+                  image_link: ''
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Body
+        components:
+          a9168e9d-61f5-47c4-9c2d-514547850699:
+            uuid: a9168e9d-61f5-47c4-9c2d-514547850699
+            region: content
+            configuration:
+              id: 'field_block:node:news:body'
+              label: Body
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: text_default
+                settings: {  }
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 7
+        third_party_settings: {  }
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: node.news.default
+targetEntityType: node
+bundle: news
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_oel_news_featured_media:
+    type: entity_reference_entity_view
+    weight: 13
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_oel_news_introduction:
+    weight: 12
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  links:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_oel_news_publication_date: true
+  langcode: true
+  layout_builder__layout: true

--- a/config/install/core.entity_view_display.node.news.landing_page.yml
+++ b/config/install/core.entity_view_display.node.news.landing_page.yml
@@ -1,0 +1,47 @@
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.node.landing_page
+    - field.field.node.news.body
+    - field.field.node.news.field_oel_news_featured_media
+    - field.field.node.news.field_oel_news_introduction
+    - field.field.node.news.field_oel_news_publication_date
+    - field.field.node.news.layout_builder__layout
+    - node.type.news
+  module:
+    - field_layout
+    - layout_builder
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: node.news.landing_page
+targetEntityType: node
+bundle: news
+mode: landing_page
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_oel_news_featured_media: true
+  field_oel_news_introduction: true
+  field_oel_news_publication_date: true
+  langcode: true
+  layout_builder__layout: true

--- a/config/install/core.entity_view_display.node.news.search_index.yml
+++ b/config/install/core.entity_view_display.node.news.search_index.yml
@@ -1,0 +1,164 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.news.body
+    - field.field.node.news.field_oel_news_featured_media
+    - field.field.node.news.field_oel_news_introduction
+    - field.field.node.news.field_oel_news_publication_date
+    - field.field.node.news.layout_builder__layout
+    - node.type.news
+  module:
+    - field_layout
+    - layout_builder
+    - layout_discovery
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Media
+        components:
+          8e02fee3-89b2-426d-a485-f8dd1894147d:
+            uuid: 8e02fee3-89b2-426d-a485-f8dd1894147d
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_featured_media'
+              label: 'Featured media'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: media_thumbnail
+                settings:
+                  image_style: thumbnail
+                  image_link: content
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: Metadata
+        components:
+          ce6078ed-5b0b-4e38-a65a-2895b4d9ca7f:
+            uuid: ce6078ed-5b0b-4e38-a65a-2895b4d9ca7f
+            region: content
+            configuration:
+              id: 'field_block:node:news:type'
+              label: 'Content type'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: entity_reference_label
+                settings:
+                  link: true
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+            additional: {  }
+            weight: 0
+          8daee0a1-7fcb-40e2-970e-ec00ec5db3d4:
+            uuid: 8daee0a1-7fcb-40e2-970e-ec00ec5db3d4
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_publication_date'
+              label: 'Publication date'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: datetime_default
+                settings:
+                  timezone_override: ''
+                  format_type: publication_date
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+            additional: {  }
+            weight: 1
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: 'Main content'
+        components:
+          b3ca2865-b129-4f8e-b9a1-059679e90b63:
+            uuid: b3ca2865-b129-4f8e-b9a1-059679e90b63
+            region: content
+            configuration:
+              id: 'field_block:node:news:field_oel_news_introduction'
+              label: Introduction
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: plain_string_formatter
+                settings:
+                  link_to_entity: false
+                  wrap_tag: _none
+                  wrap_class: hide-mobile
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 1
+          e9d381b1-8597-466e-accb-cb70efe3940e:
+            uuid: e9d381b1-8597-466e-accb-cb70efe3940e
+            region: content
+            configuration:
+              id: 'field_block:node:news:title'
+              label: Title
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: string
+                settings:
+                  link_to_entity: true
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
+  field_layout:
+    id: layout_onecol
+    settings:
+      label: ''
+id: node.news.search_index
+targetEntityType: node
+bundle: news
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_oel_news_featured_media: true
+  field_oel_news_introduction: true
+  field_oel_news_publication_date: true
+  langcode: true
+  layout_builder__layout: true

--- a/config/install/core.entity_view_mode.node.cards.yml
+++ b/config/install/core.entity_view_mode.node.cards.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.cards
+label: Cards
+targetEntityType: node
+cache: true

--- a/config/install/core.entity_view_mode.node.landing_page.yml
+++ b/config/install/core.entity_view_mode.node.landing_page.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.landing_page
+label: 'Landing Page'
+targetEntityType: node
+cache: true

--- a/config/install/editor.editor.html.yml
+++ b/config/install/editor.editor.html.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.html
+  module:
+    - ckeditor
+format: html
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Media
+          items:
+            - Blockquote
+            - DrupalImage
+        -
+          name: Tools
+          items:
+            - Source
+  plugins:
+    stylescombo:
+      styles: ''
+    language:
+      language_list: un
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/config/install/field.field.media.featured_media.field_media_image.yml
+++ b/config/install/field.field.media.featured_media.field_media_image.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_image
+    - media.type.featured_media
+  module:
+    - content_translation
+    - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
+id: media.featured_media.field_media_image
+field_name: field_media_image
+entity_type: media
+bundle: featured_media
+label: Image
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: true
+  title_field_required: true
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/install/field.field.node.news.body.yml
+++ b/config/install/field.field.node.news.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.news
+  module:
+    - text
+id: node.news.body
+field_name: body
+entity_type: node
+bundle: news
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/config/install/field.field.node.news.field_oel_news_featured_media.yml
+++ b/config/install/field.field.node.news.field_oel_news_featured_media.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_oel_news_featured_media
+    - media.type.featured_media
+    - node.type.news
+id: node.news.field_oel_news_featured_media
+field_name: field_oel_news_featured_media
+entity_type: node
+bundle: news
+label: 'Featured media'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      featured_media: featured_media
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.news.field_oel_news_introduction.yml
+++ b/config/install/field.field.node.news.field_oel_news_introduction.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_oel_news_introduction
+    - node.type.news
+id: node.news.field_oel_news_introduction
+field_name: field_oel_news_introduction
+entity_type: node
+bundle: news
+label: Introduction
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.node.news.field_oel_news_publication_date.yml
+++ b/config/install/field.field.node.news.field_oel_news_publication_date.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_oel_news_publication_date
+    - node.type.news
+  module:
+    - datetime
+id: node.news.field_oel_news_publication_date
+field_name: field_oel_news_publication_date
+entity_type: node
+bundle: news
+label: 'Publication date'
+description: 'Date when this article was originally published.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/install/field.field.node.news.layout_builder__layout.yml
+++ b/config/install/field.field.node.news.layout_builder__layout.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.layout_builder__layout
+    - node.type.news
+  module:
+    - layout_builder
+id: node.news.layout_builder__layout
+field_name: layout_builder__layout
+entity_type: node
+bundle: news
+label: Layout
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: layout_section

--- a/config/install/field.storage.media.field_media_image.yml
+++ b/config/install/field.storage.media.field_media_image.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - media
+id: media.field_media_image
+field_name: field_media_image
+entity_type: media
+type: image
+settings:
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_oel_news_featured_media.yml
+++ b/config/install/field.storage.node.field_oel_news_featured_media.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_oel_news_featured_media
+field_name: field_oel_news_featured_media
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_oel_news_introduction.yml
+++ b/config/install/field.storage.node.field_oel_news_introduction.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_oel_news_introduction
+field_name: field_oel_news_introduction
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_oel_news_publication_date.yml
+++ b/config/install/field.storage.node.field_oel_news_publication_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_oel_news_publication_date
+field_name: field_oel_news_publication_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.layout_builder__layout.yml
+++ b/config/install/field.storage.node.layout_builder__layout.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - layout_builder
+    - node
+id: node.layout_builder__layout
+field_name: layout_builder__layout
+entity_type: node
+type: layout_section
+settings: {  }
+module: layout_builder
+locked: true
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/filter.format.html.yml
+++ b/config/install/filter.format.html.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies: {  }
+name: HTML
+format: html
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid>'
+      filter_html_help: true
+      filter_html_nofollow: false

--- a/config/install/language.content_settings.media.featured_media.yml
+++ b/config/install/language.content_settings.media.featured_media.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.featured_media
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.featured_media
+target_entity_type_id: media
+target_bundle: featured_media
+default_langcode: site_default
+language_alterable: false

--- a/config/install/language.content_settings.node.news.yml
+++ b/config/install/language.content_settings.node.news.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.news
+target_entity_type_id: node
+target_bundle: news
+default_langcode: site_default
+language_alterable: false

--- a/config/install/media.type.featured_media.yml
+++ b/config/install/media.type.featured_media.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+id: featured_media
+label: 'News Featured media'
+description: 'News featured media'
+source: image
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_image
+field_map:
+  name: name

--- a/config/install/node.type.news.yml
+++ b/config/install/node.type.news.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - oel_news
+name: News
+type: news
+description: 'News articles'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/config/install/views.view.news.yml
+++ b/config/install/views.view.news.yml
@@ -1,0 +1,609 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.cards
+    - core.entity_view_mode.node.search_index
+    - field.storage.node.field_oel_news_featured_media
+    - field.storage.node.field_oel_news_publication_date
+    - image.style.media_library
+    - node.type.news
+  module:
+    - datetime
+    - media
+    - node
+    - user
+id: news
+label: News
+module: views
+description: 'Provided by the module oel_news'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 3
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+        field_oel_news_featured_media:
+          id: field_oel_news_featured_media
+          table: node__field_oel_news_featured_media
+          field: field_oel_news_featured_media
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_style: media_library
+            image_link: content
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_oel_news_publication_date:
+          id: field_oel_news_publication_date
+          table: node__field_oel_news_publication_date
+          field: field_oel_news_publication_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_custom
+          settings:
+            timezone_override: ''
+            date_format: 'd M Y'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: 'Published status'
+            description: null
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            news: news
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      sorts:
+        field_oel_news_publication_date_value:
+          id: field_oel_news_publication_date_value
+          table: node__field_oel_news_publication_date
+          field: field_oel_news_publication_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          plugin_id: datetime
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      title: 'Recent News'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_oel_news_featured_media'
+        - 'config:field.storage.node.field_oel_news_publication_date'
+  news_recent:
+    display_plugin: block
+    id: news_recent
+    display_title: 'Recent News'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Recent News'
+      display_description: ''
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      defaults:
+        style: false
+        row: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: cards
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_oel_news_featured_media'
+        - 'config:field.storage.node.field_oel_news_publication_date'
+  news_search:
+    display_plugin: page
+    id: news_search
+    display_title: 'News Search'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: news
+      display_description: ''
+      title: 'News Search'
+      defaults:
+        title: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: search_index
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: 'Published status'
+            description: null
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            news: news
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_oel_news_publication_date_value:
+          id: field_oel_news_publication_date_value
+          table: node__field_oel_news_publication_date
+          field: field_oel_news_publication_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_oel_news_publication_date_value_op
+            label: Date
+            description: ''
+            use_operator: false
+            operator: field_oel_news_publication_date_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_oel_news_publication_date_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      exposed_block: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_oel_news_featured_media'
+        - 'config:field.storage.node.field_oel_news_publication_date'

--- a/oel_news.info.yml
+++ b/oel_news.info.yml
@@ -1,6 +1,22 @@
-name: OpenEuropa News
-description: OpenEuropa News.
+name: OEL News
+description: OEL News
 package: OpenEuropa
 
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
+dependencies:
+  - drupal:ckeditor
+  - drupal:datetime
+  - drupal:image
+  - drupal:link
+  - drupal:text
+  - drupal:content_translation
+  - drupal:language
+  - drupal:field
+  - drupal:views
+  - drupal:media
+  - drupal:media_library
+  - drupal:layout_builder
+  - drupal:layout_discovery
+  - drupal:field_layout


### PR DESCRIPTION
## OPENEUROPA-50

### Description

This PR contains the configuration for tickets:
OEL-50 OEL-52, OEL-53 and OEL-54.

Since the POC I had created had basically all the elements already implemented and working, to avoid spending time recreating it I reused the configuration and amended smaller details missing in the POC.

### Change log

- Added: 
-   Initial Content type configuration
-   Base fields
-   Media Library
-   Content Displays
-   Date format
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

docker-compose up -d
docker-compose composer install
docker-compose exec web ./vendor/bin/run drupal:site-install

